### PR TITLE
Fix icon mismatch for debit card features

### DIFF
--- a/rewards/credit-cards.html
+++ b/rewards/credit-cards.html
@@ -165,7 +165,7 @@
                     </div>
                     <div class="cf-choose-feature-wrapper">
                       <div class="cf-choose-feature-bold-text-16px">Not included:</div>
-                      <div class="cf-pricing-plan-pointers"><img src="../images/Apple-Card.png" loading="lazy" sizes="100vw" srcset="../images/Apple-Card-p-500.png 500w, ../images/Apple-Card-p-800.png 800w, ../images/Apple-Card.png 849w" alt="" class="cf-choose-feature-check-icon">
+                      <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">
                         <div class="cf-feature-pointer-text-20px">Limited Fraud Protection</div>
                       </div>
                       <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">


### PR DESCRIPTION
## Summary
- fix mismatching icon for Limited Fraud Protection under debit card features

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862c8feb240832297be7ad7815a972b