### PR TITLE
Fix broken X icon for "Limited Fraud Protection" in Debit Card section

### DIFF
--- a/rewards/credit-cards.html
+++ b/rewards/credit-cards.html
@@ -165,7 +165,7 @@
                     </div>
                     <div class="cf-choose-feature-wrapper">
                       <div class="cf-choose-feature-bold-text-16px">Not included:</div>
-                      <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">
+                      <div class="cf-pricing-plan-pointers"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" class="cf-choose-feature-check-icon"><path d="M16 28C22.6274 28 28 22.6274 28 16C28 9.37258 22.6274 4 16 4C9.37258 4 4 9.37258 4 16C4 22.6274 9.37258 28 16 28Z" stroke="black" stroke-width="2" stroke-miterlimit="10"/><path d="M20 12L12 20" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 20L12 12" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
                         <div class="cf-feature-pointer-text-20px">Limited Fraud Protection</div>
                       </div>
                       <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">


### PR DESCRIPTION
The first XCircle icon in the Debit Card comparison section was rendering as an Apple Card image due to a browser lazy-loading/rendering issue. Replaced the <img> tag with an inline SVG to ensure the icon always displays correctly.

https://claude.ai/code/session_0138XVPAnjJFHuMJzXgqYyt4