### PR TITLE
Fix Rewards dropdown: add CSS hover/focus fallback

### DIFF
--- a/css/feruzs-urazaliev.webflow.css
+++ b/css/feruzs-urazaliev.webflow.css
@@ -584,6 +584,23 @@ p {
   overflow: visible;
 }
 
+.w-dropdown:hover > .w-dropdown-list,
+.w-dropdown:focus-within > .w-dropdown-list {
+  display: block;
+}
+
+.w-dropdown:hover > .cf-dropdown-lists,
+.w-dropdown:focus-within > .cf-dropdown-lists {
+  box-shadow: none;
+  width: 100%;
+  padding-top: 8px;
+  top: 72px;
+  bottom: auto;
+  left: 0%;
+  right: 0%;
+  overflow: visible;
+}
+
 .cf-navigation-1-link {
   color: #fff;
   text-transform: capitalize;


### PR DESCRIPTION
The Webflow dropdown relies on webflow.js to add the .w--open class on click, which may not initialize properly outside Webflow hosting. This adds a CSS-only hover and focus-within fallback so the dropdown opens reliably on all pages.

https://claude.ai/code/session_01RsWBNLgDrJiGWK4uDiVMW1