### PR TITLE
Fix Rewards dropdown with JS click handler, revert CSS hover hack

### DIFF
--- a/bio.html
+++ b/bio.html
@@ -590,5 +590,6 @@
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=6692ba1531d937ab5ed9be8a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>
+  <script src="js/dropdown-fix.js" type="text/javascript"></script>
 </body>
 </html>

--- a/css/feruzs-urazaliev.webflow.css
+++ b/css/feruzs-urazaliev.webflow.css
@@ -584,23 +584,6 @@ p {
   overflow: visible;
 }
 
-.w-dropdown:hover > .w-dropdown-list,
-.w-dropdown:focus-within > .w-dropdown-list {
-  display: block;
-}
-
-.w-dropdown:hover > .cf-dropdown-lists,
-.w-dropdown:focus-within > .cf-dropdown-lists {
-  box-shadow: none;
-  width: 100%;
-  padding-top: 8px;
-  top: 72px;
-  bottom: auto;
-  left: 0%;
-  right: 0%;
-  overflow: visible;
-}
-
 .cf-navigation-1-link {
   color: #fff;
   text-transform: capitalize;

--- a/index.html
+++ b/index.html
@@ -208,6 +208,7 @@
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=6692ba1531d937ab5ed9be8a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>
+  <script src="js/dropdown-fix.js" type="text/javascript"></script>
   <script src="https://unpkg.com/@studio-freight/lenis@1.0.36/dist/lenis.min.js"></script>
   <script>
       window.addEventListener("DOMContentLoaded", (event) => {

--- a/js/dropdown-fix.js
+++ b/js/dropdown-fix.js
@@ -1,0 +1,31 @@
+// Fix Webflow dropdown when hosted outside Webflow
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll(".w-dropdown-toggle").forEach(function (toggle) {
+    toggle.addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var dropdown = toggle.closest(".w-dropdown");
+      var list = dropdown.querySelector(".w-dropdown-list");
+      var isOpen = list.classList.contains("w--open");
+
+      // Close all other dropdowns first
+      document.querySelectorAll(".w-dropdown-list.w--open").forEach(function (openList) {
+        openList.classList.remove("w--open");
+      });
+
+      // Toggle this one
+      if (!isOpen) {
+        list.classList.add("w--open");
+      }
+    });
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener("click", function (e) {
+    if (!e.target.closest(".w-dropdown")) {
+      document.querySelectorAll(".w-dropdown-list.w--open").forEach(function (openList) {
+        openList.classList.remove("w--open");
+      });
+    }
+  });
+});

--- a/rewards/banking.html
+++ b/rewards/banking.html
@@ -170,5 +170,6 @@
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=6692ba1531d937ab5ed9be8a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../js/webflow.js" type="text/javascript"></script>
+  <script src="../js/dropdown-fix.js" type="text/javascript"></script>
 </body>
 </html>

--- a/rewards/coupons.html
+++ b/rewards/coupons.html
@@ -293,5 +293,6 @@
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=6692ba1531d937ab5ed9be8a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../js/webflow.js" type="text/javascript"></script>
+  <script src="../js/dropdown-fix.js" type="text/javascript"></script>
 </body>
 </html>

--- a/rewards/credit-cards.html
+++ b/rewards/credit-cards.html
@@ -556,5 +556,6 @@
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=6692ba1531d937ab5ed9be8a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../js/webflow.js" type="text/javascript"></script>
+  <script src="../js/dropdown-fix.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
The CSS hover fallback was triggering in wrong areas between nav items. Replaced with a proper JS click handler (dropdown-fix.js) that toggles the .w--open class on .w-dropdown-toggle click, matching Webflow's expected behavior. Closes dropdown when clicking outside.

https://claude.ai/code/session_01RsWBNLgDrJiGWK4uDiVMW1