### PR TITLE
Fix incorrect icon for Limited Fraud Protection in debit card comparison

### DIFF
--- a/rewards/credit-cards.html
+++ b/rewards/credit-cards.html
@@ -165,7 +165,7 @@
                     </div>
                     <div class="cf-choose-feature-wrapper">
                       <div class="cf-choose-feature-bold-text-16px">Not included:</div>
-                      <div class="cf-pricing-plan-pointers"><img src="../images/Apple-Card.png" loading="lazy" sizes="100vw" srcset="../images/Apple-Card-p-500.png 500w, ../images/Apple-Card-p-800.png 800w, ../images/Apple-Card.png 849w" alt="" class="cf-choose-feature-check-icon">
+                      <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">
                         <div class="cf-feature-pointer-text-20px">Limited Fraud Protection</div>
                       </div>
                       <div class="cf-pricing-plan-pointers"><img src="../images/XCircle.svg" loading="lazy" alt="" class="cf-choose-feature-check-icon">


### PR DESCRIPTION
Replace Apple-Card.png with XCircle.svg to match the other debit card list items.

https://claude.ai/code/session_01MP8J4CCShmNfTcLm5kYKZM