### PR TITLE
Add type="button" to buttons and improve accessibility

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          # Auto-enable Pages on first run + ensure the Source is "GitHub
+          # Actions" so the workflow doesn't 404 when the repo's Pages
+          # config hasn't been touched yet.
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/globals.jsx
+++ b/globals.jsx
@@ -654,7 +654,7 @@ function ChessBoard() {
                 <div key={m.ply}>{m.ply}. {m.t === "w" ? "" : "… "}{m.n}</div>
               ))}
         </div>
-        <button className="chess-reset" onClick={reset}>↻ Reset</button>
+        <button type="button" className="chess-reset" onClick={reset}>↻ Reset</button>
         <a className="link-amber" href="https://www.chess.com/" target="_blank" rel="noreferrer" style={{borderBottom:0, fontFamily:"var(--font-mono)", fontSize:11, letterSpacing:"0.12em", textTransform:"uppercase", color:"var(--violet)"}}>
           Real game on Chess.com →
         </a>
@@ -1068,6 +1068,7 @@ function WireGlobe({ size = 420 }) {
           : <span>UTC <em>{hud.utc}</em></span>}
       </div>
       <button
+        type="button"
         className="wire-globe-locate"
         onClick={locate}
         disabled={locState==="locating"||locState==="located"}
@@ -1114,6 +1115,7 @@ function GoodreadsQuote({ num = "004", user = "urazaliev_f" }) {
       <div style={{display:"flex", alignItems:"center", justifyContent:"space-between", flexWrap:"wrap", gap:12, marginTop:16}}>
         <div className="attrib">— {q.attrib}</div>
         <button
+          type="button"
           onClick={cycle}
           style={{
             fontFamily: "var(--font-mono)",
@@ -1154,6 +1156,10 @@ function SplineScene({ url = "https://prod.spline.design/Lqu1KhxLD6g3YGtG/scene.
     && window.matchMedia
     && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   if (reduce) return null;
+  // Opt-out: <html data-no-spline> hides the backdrop site-wide for slow
+  // devices / debugging without touching JS or the per-page Tweaks panel.
+  if (typeof document !== "undefined"
+      && document.documentElement.hasAttribute("data-no-spline")) return null;
   return (
     <div className="spline-bg" aria-hidden="true">
       <spline-viewer

--- a/rewards-coupons.jsx
+++ b/rewards-coupons.jsx
@@ -155,7 +155,7 @@ function CouponCard({ c }) {
         )}
         {c.code && (
           <div style={{marginTop: 10}}>
-            <button onClick={copy} className={"rw-coupon-code " + (copied ? "is-copied" : "")}>
+            <button type="button" onClick={copy} className={"rw-coupon-code " + (copied ? "is-copied" : "")}>
               <span>{c.code}</span>
               <span className="copy-tip">{copied ? "✓ COPIED" : "CLICK TO COPY"}</span>
             </button>

--- a/site-shell.jsx
+++ b/site-shell.jsx
@@ -108,19 +108,4 @@ function SiteFooter() {
   );
 }
 
-/* ─────────────────────────────────────────────────────────────────
-   AestheticToggle — Tweaks-driven swap between Glasswork & Paper
-   ───────────────────────────────────────────────────────────────── */
-function useAestheticTweak() {
-  /* Read default from <html data-aesthetic>; sync on storage events.
-     Persist via __edit_mode_set_keys is handled in the per-page Tweaks panel. */
-  const [aesthetic, setAesthetic] = useState(() =>
-    document.documentElement.getAttribute("data-aesthetic") || "glass"
-  );
-  useEffect(() => {
-    document.documentElement.setAttribute("data-aesthetic", aesthetic);
-  }, [aesthetic]);
-  return [aesthetic, setAesthetic];
-}
-
-Object.assign(window, { SiteNav, SiteFooter, useAestheticTweak });
+Object.assign(window, { SiteNav, SiteFooter });

--- a/tweaks-panel.jsx
+++ b/tweaks-panel.jsx
@@ -235,7 +235,7 @@ function TweaksPanel({ title = 'Tweaks', children }) {
            style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
         <div className="twk-hd" onMouseDown={onDragStart}>
           <b>{title}</b>
-          <button className="twk-x" aria-label="Close tweaks"
+          <button type="button" className="twk-x" aria-label="Close tweaks"
                   onMouseDown={(e) => e.stopPropagation()}
                   onClick={dismiss}>✕</button>
         </div>

--- a/writing.jsx
+++ b/writing.jsx
@@ -76,6 +76,7 @@ function WritingApp() {
             {tags.map(tag => (
               <button
                 key={tag}
+                type="button"
                 className={"tag-filter " + (filter === tag ? "is-active" : "")}
                 onClick={() => setFilter(tag)}
               >


### PR DESCRIPTION
## Summary
This PR improves code quality and accessibility across the codebase by adding explicit `type="button"` attributes to button elements and removing unused code.

## Key Changes
- **Button type attributes**: Added `type="button"` to all `<button>` elements that don't submit forms (ChessBoard reset, WireGlobe locate, GoodreadsQuote cycle, CouponCard copy, TweaksPanel close, WritingApp tag filters). This prevents unintended form submission behavior and is an HTML best practice.
- **Removed unused hook**: Deleted `useAestheticTweak()` from site-shell.jsx as it's no longer needed, along with its export from the window object.
- **Spline scene optimization**: Added opt-out mechanism via `data-no-spline` HTML attribute to disable Spline backdrop for slow devices or debugging without modifying JS or the Tweaks panel.
- **GitHub Pages workflow**: Enhanced static.yml to auto-enable Pages on first run and ensure the workflow source is set to "GitHub Actions" to prevent 404 errors when Pages config hasn't been initialized.

## Implementation Details
- The `type="button"` additions ensure buttons behave as interactive elements rather than form submission triggers, improving predictability and reducing potential bugs.
- The Spline opt-out check includes a guard for SSR environments (`typeof document !== "undefined"`).
- GitHub Pages enablement is now automatic, improving the initial setup experience for new repositories.

https://claude.ai/code/session_01Asotjno2kJ274Z53tsetkj