### PR TITLE
Add card-tracking workflows and chess page

### DIFF
--- a/.github/scripts/track_card_updates.py
+++ b/.github/scripts/track_card_updates.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Scan card-news RSS feeds for items mentioning cards listed in
+rewards-cards.jsx, and open a GitHub issue summarizing matches."""
+
+import os
+import re
+import sys
+import subprocess
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+FEEDS = [
+    ("Doctor of Credit", "https://www.doctorofcredit.com/feed/"),
+    ("Frequent Miler", "https://frequentmiler.com/feed/"),
+    ("One Mile at a Time", "https://onemileatatime.com/feed/"),
+]
+LOOKBACK_DAYS = 14
+JSX_PATH = Path("rewards-cards.jsx")
+STOPWORDS = {"card", "cards", "the", "and", "of", "for", "blue", "gold", "platinum"}
+
+
+def load_cards(path: Path):
+    text = path.read_text(encoding="utf-8")
+    brands = re.findall(r'^\s*brand:\s*"([^"]+)"', text, re.MULTILINE)
+    names = re.findall(r'^\s*name:\s*"([^"]+)"', text, re.MULTILINE)
+    return [(b.strip(), n.strip()) for b, n in zip(brands, names)]
+
+
+def fetch(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "card-tracker/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.read()
+
+
+def parse_feed(name: str, url: str):
+    try:
+        data = fetch(url)
+        root = ET.fromstring(data)
+    except Exception as e:
+        print(f"[warn] {name}: {e}", file=sys.stderr)
+        return []
+    out = []
+    for item in root.iter("item"):
+        title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        pub = (item.findtext("pubDate") or "").strip()
+        try:
+            dt = datetime.strptime(pub, "%a, %d %b %Y %H:%M:%S %z")
+        except ValueError:
+            dt = None
+        out.append({"title": title, "link": link, "date": dt, "source": name})
+    return out
+
+
+def card_tokens(brand: str, name: str):
+    tokens = re.split(r"[\s\-]+", f"{brand} {name}")
+    return [t.lower() for t in tokens if len(t) >= 4 and t.lower() not in STOPWORDS]
+
+
+def matches(item, brand: str, name: str) -> bool:
+    title = item["title"].lower()
+    tokens = card_tokens(brand, name)
+    if not tokens:
+        return False
+    return all(t in title for t in tokens[:2]) or (
+        brand.lower().split()[0] in title and any(t in title for t in tokens)
+    )
+
+
+def main() -> int:
+    if not JSX_PATH.exists():
+        print(f"[fatal] {JSX_PATH} not found", file=sys.stderr)
+        return 1
+    cards = load_cards(JSX_PATH)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=LOOKBACK_DAYS)
+
+    by_card: dict[str, list[dict]] = {}
+    for source_name, url in FEEDS:
+        for item in parse_feed(source_name, url):
+            if item["date"] and item["date"] < cutoff:
+                continue
+            for brand, name in cards:
+                if matches(item, brand, name):
+                    by_card.setdefault(f"{brand} — {name}", []).append(item)
+
+    if not by_card:
+        print("No relevant items in the lookback window.")
+        return 0
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    title = f"Card-news scan — {today}"
+    lines = [
+        f"Scan window: last {LOOKBACK_DAYS} days across {len(FEEDS)} feeds.",
+        "",
+        "Verify welcome offers, fees, and benefits against the issuer page",
+        "before editing `rewards-cards.jsx`.",
+        "",
+    ]
+    for card_label in sorted(by_card):
+        lines.append(f"### {card_label}")
+        seen = set()
+        for item in by_card[card_label]:
+            key = item["link"] or item["title"]
+            if key in seen:
+                continue
+            seen.add(key)
+            lines.append(f"- [{item['title']}]({item['link']}) — *{item['source']}*")
+        lines.append("")
+    body = "\n".join(lines)
+
+    repo = os.environ["GH_REPO"]
+    subprocess.run(
+        ["gh", "issue", "create", "-R", repo, "-t", title, "-b", body],
+        check=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cards-pull.yml
+++ b/.github/workflows/cards-pull.yml
@@ -1,0 +1,24 @@
+name: Pull card-news mentions
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Scan feeds and open issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: python .github/scripts/track_card_updates.py

--- a/.github/workflows/cards-validate.yml
+++ b/.github/workflows/cards-validate.yml
@@ -1,0 +1,83 @@
+name: Validate cards
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  pull_request:
+    paths:
+      - 'rewards-cards.jsx'
+      - 'images/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  models: read
+
+jobs:
+  image-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify referenced images exist on disk
+        run: |
+          set -euo pipefail
+          missing=$(grep -oE '^[[:space:]]*image:[[:space:]]*"[^"]+"' rewards-cards.jsx \
+            | sed -E 's/.*image:[[:space:]]*"([^"]+)".*/\1/' \
+            | sort -u \
+            | while read -r p; do [ -f "$p" ] || echo "$p"; done)
+          if [ -n "$missing" ]; then
+            echo "::error::Missing image files referenced from rewards-cards.jsx:"
+            echo "$missing"
+            exit 1
+          fi
+          echo "All referenced images exist."
+
+  llm-diff-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build prompt from diff
+        run: |
+          set -euo pipefail
+          {
+            echo "You are reviewing a change to a credit-card list (rewards-cards.jsx)."
+            echo "Each card object has: brand, name, image, af, welcome, desc, benefits[], href."
+            echo
+            echo "Flag anything suspicious. Examples of suspicious changes:"
+            echo "- Annual fee dropped to \$0 on a premium card."
+            echo "- Welcome offer above 500k points or below 5k for a known premium card."
+            echo "- A signature permanent benefit removed (e.g. lounge access on Platinum)."
+            echo "- Referral href belongs to a different brand than the card."
+            echo "- Image path no longer matches the card name."
+            echo
+            echo "Reply with a short bullet list of concerns. If nothing is suspicious,"
+            echo "reply exactly: Looks fine."
+            echo
+            echo "DIFF:"
+            git diff "${{ github.event.pull_request.base.sha }}" \
+                    "${{ github.event.pull_request.head.sha }}" \
+                    -- rewards-cards.jsx | head -c 12000
+          } > prompt.txt
+      - id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o-mini
+          prompt-file: prompt.txt
+      - name: Comment review on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          {
+            echo "**Card-diff review** (gpt-4o-mini via GitHub Models)"
+            echo
+            echo "${{ steps.ai.outputs.response }}"
+          } > review.md
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file review.md

--- a/chess.css
+++ b/chess.css
@@ -1,0 +1,88 @@
+.chess-board {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  width: min(560px, 92vw);
+  aspect-ratio: 1 / 1;
+  border-radius: var(--r-2);
+  overflow: hidden;
+  border: 1px solid var(--hairline-strong);
+  box-shadow: 0 24px 60px var(--violet-glow);
+  user-select: none;
+}
+
+.chess-board .sq {
+  all: unset;
+  display: grid;
+  place-items: center;
+  font-size: clamp(28px, 6vw, 44px);
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+  position: relative;
+}
+
+.chess-board .sq.light { background: #ece6d6; color: #1a1a1a; }
+.chess-board .sq.dark  { background: #6b5b3e; color: #f8f4ea; }
+
+.chess-board .sq.sel {
+  outline: 3px solid var(--amber);
+  outline-offset: -3px;
+  z-index: 1;
+}
+
+.chess-board .sq.hint::after {
+  content: "";
+  position: absolute;
+  width: 28%;
+  height: 28%;
+  border-radius: 50%;
+  background: rgba(122, 92, 255, 0.55);
+}
+
+.chess-board .sq.hint:has-text-content::after,
+.chess-board .sq.hint.capture::after {
+  width: 70%;
+  height: 70%;
+  background: transparent;
+  border: 3px solid rgba(122, 92, 255, 0.55);
+}
+
+.chess-status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-sm);
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--lumen);
+}
+
+.chess-controls {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chess-meta {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  max-width: 560px;
+}
+
+.chess-meta .pill {
+  padding: 10px 14px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--hairline-strong);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.chess-meta .pill strong {
+  color: var(--lumen);
+  font-weight: 500;
+  margin-left: 6px;
+}

--- a/chess.html
+++ b/chess.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en" data-aesthetic="glass">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Chess · Feruz Urazaliev</title>
+  <meta name="description" content="A small in-browser chess game — you play white against a JavaScript minimax engine." />
+  <meta property="og:title" content="Chess · Feruz Urazaliev" />
+  <meta property="og:description" content="A small in-browser chess game — you play white against a JavaScript minimax engine." />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Chess · Feruz Urazaliev" />
+  <meta name="twitter:description" content="A small in-browser chess game — you play white against a JavaScript minimax engine." />
+  <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon" />
+  <link href="images/webclip.png" rel="apple-touch-icon" />
+
+  <link rel="stylesheet" href="colors_and_type.css" />
+  <link rel="stylesheet" href="field-notebook.css" />
+  <link rel="stylesheet" href="site.css" />
+  <link rel="stylesheet" href="globals.css" />
+  <link rel="stylesheet" href="chess.css" />
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js" crossorigin="anonymous"></script>
+
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@splinetool/viewer/build/spline-viewer.js"></script>
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-RXQRZ31KSJ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-RXQRZ31KSJ');
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="tweaks-panel.jsx"></script>
+  <script type="text/babel" src="site-shell.jsx"></script>
+  <script type="text/babel" src="globals.jsx"></script>
+  <script type="text/babel" src="chess.jsx"></script>
+</body>
+</html>

--- a/chess.jsx
+++ b/chess.jsx
@@ -1,0 +1,268 @@
+/* global React, ReactDOM, Chess, SiteNav, SiteFooter, useTweaks, TweaksPanel, TweakSection, TweakRadio, TweakSelect, OrbField, StatusBar, SplineScene */
+
+const CHESS_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "aesthetic": "glass",
+  "font": "classic",
+  "showOrbs": true,
+  "showStatusBar": true,
+  "depth": 3
+}/*EDITMODE-END*/;
+
+const PIECE_VALUE = { p: 100, n: 320, b: 330, r: 500, q: 900, k: 0 };
+
+const PIECE_GLYPH = {
+  wK: "♔", wQ: "♕", wR: "♖", wB: "♗", wN: "♘", wP: "♙",
+  bK: "♚", bQ: "♛", bR: "♜", bB: "♝", bN: "♞", bP: "♟",
+};
+
+function evaluate(game) {
+  if (game.in_checkmate()) return game.turn() === "w" ? -1e6 : 1e6;
+  if (game.in_draw() || game.in_stalemate() || game.in_threefold_repetition()) return 0;
+  let score = 0;
+  for (const row of game.board()) {
+    for (const sq of row) {
+      if (!sq) continue;
+      const v = PIECE_VALUE[sq.type];
+      score += sq.color === "w" ? v : -v;
+    }
+  }
+  return score;
+}
+
+function search(game, depth, alpha, beta, maximizing) {
+  if (depth === 0 || game.game_over()) {
+    return [evaluate(game), null];
+  }
+  const moves = game.moves();
+  for (let i = moves.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [moves[i], moves[j]] = [moves[j], moves[i]];
+  }
+  let best = null;
+  if (maximizing) {
+    let value = -Infinity;
+    for (const m of moves) {
+      game.move(m);
+      const [v] = search(game, depth - 1, alpha, beta, false);
+      game.undo();
+      if (v > value) { value = v; best = m; }
+      if (value > alpha) alpha = value;
+      if (alpha >= beta) break;
+    }
+    return [value, best];
+  } else {
+    let value = Infinity;
+    for (const m of moves) {
+      game.move(m);
+      const [v] = search(game, depth - 1, alpha, beta, true);
+      game.undo();
+      if (v < value) { value = v; best = m; }
+      if (value < beta) beta = value;
+      if (alpha >= beta) break;
+    }
+    return [value, best];
+  }
+}
+
+function ChessApp() {
+  const [t, setTweak] = useTweaks(CHESS_DEFAULTS);
+  const gameRef = React.useRef(null);
+  if (!gameRef.current) gameRef.current = new Chess();
+  const game = gameRef.current;
+
+  const [, setTick] = React.useState(0);
+  const refresh = () => setTick(x => x + 1);
+
+  const [selected, setSelected] = React.useState(null);
+  const [thinking, setThinking] = React.useState(false);
+  const [history, setHistory] = React.useState([]);
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute("data-aesthetic", t.aesthetic);
+    document.documentElement.setAttribute("data-font", t.font);
+  }, [t.aesthetic, t.font]);
+
+  const status = (() => {
+    if (game.in_checkmate()) return game.turn() === "w" ? "Checkmate. Engine wins." : "Checkmate. You win.";
+    if (game.in_stalemate()) return "Stalemate.";
+    if (game.in_draw()) return "Draw.";
+    if (thinking) return "Engine thinking…";
+    if (game.in_check()) return game.turn() === "w" ? "You are in check." : "Engine is in check.";
+    return game.turn() === "w" ? "Your move (white)." : "Engine to move.";
+  })();
+
+  const playEngine = React.useCallback(() => {
+    if (game.game_over()) return;
+    setThinking(true);
+    setTimeout(() => {
+      const depth = Math.max(1, Math.min(4, t.depth | 0));
+      const [, m] = search(game, depth, -Infinity, Infinity, false);
+      if (m) {
+        game.move(m);
+        setHistory(h => [...h, { side: "engine", san: m }]);
+      }
+      setThinking(false);
+      refresh();
+    }, 30);
+  }, [game, t.depth]);
+
+  const onSquareClick = (sq) => {
+    if (thinking || game.turn() !== "w" || game.game_over()) return;
+    if (selected) {
+      const moved = game.move({ from: selected, to: sq, promotion: "q" });
+      setSelected(null);
+      if (moved) {
+        setHistory(h => [...h, { side: "you", san: moved.san }]);
+        refresh();
+        playEngine();
+        return;
+      }
+    }
+    const piece = game.get(sq);
+    setSelected(piece && piece.color === "w" ? sq : null);
+  };
+
+  const reset = () => {
+    game.reset();
+    setSelected(null);
+    setHistory([]);
+    refresh();
+  };
+
+  const takeBack = () => {
+    if (thinking) return;
+    game.undo();
+    game.undo();
+    setSelected(null);
+    setHistory(h => h.slice(0, -2));
+    refresh();
+  };
+
+  const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  const ranks = [8, 7, 6, 5, 4, 3, 2, 1];
+  const board = game.board();
+  const hintTargets = selected
+    ? new Set(game.moves({ square: selected, verbose: true }).map(m => m.to))
+    : new Set();
+
+  return (
+    <>
+      <SplineScene />
+      {t.showOrbs && <OrbField count={6} />}
+      {t.showStatusBar && <StatusBar />}
+      <SiteNav active="chess" />
+
+      <main className="container">
+        <section data-screen-label="Chess" style={{ paddingTop: 40, paddingBottom: 80 }}>
+          <div className="hero-stamp" style={{ marginBottom: 24 }}>
+            <span><span className="num">005</span> / Chess</span>
+            <span>Minimax + alpha-beta</span>
+            <span style={{ color: "var(--lumen-2)" }}>you are white</span>
+          </div>
+
+          <h1 style={{ marginBottom: 16 }}>
+            A small <em>chess engine</em>.
+          </h1>
+
+          <p className="lead" style={{ maxWidth: 640, marginBottom: 24 }}>
+            Material-only evaluation, a couple ply ahead. Good enough to punish hanging pieces; happy to be outplayed by anyone with a plan. Click a piece, then a destination.
+          </p>
+
+          <div className="chess-status glass" style={{ marginBottom: 16, padding: "12px 16px", borderRadius: "var(--r-2)", display: "inline-block" }}>
+            {status}
+          </div>
+
+          <div className="chess-board" role="grid" aria-label="Chess board">
+            {ranks.map((rank, ri) =>
+              files.map((file, fi) => {
+                const sq = file + rank;
+                const piece = board[ri][fi];
+                const isLight = (ri + fi) % 2 === 0;
+                const isSel = selected === sq;
+                const isHint = hintTargets.has(sq);
+                const cls = `sq ${isLight ? "light" : "dark"}${isSel ? " sel" : ""}${isHint ? " hint" : ""}${isHint && piece ? " capture" : ""}`;
+                return (
+                  <button
+                    key={sq}
+                    className={cls}
+                    onClick={() => onSquareClick(sq)}
+                    aria-label={sq + (piece ? ` ${piece.color}${piece.type}` : " empty")}
+                  >
+                    {piece && PIECE_GLYPH[piece.color + piece.type.toUpperCase()]}
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          <div className="chess-controls">
+            <button className="btn btn-primary" onClick={reset}>New game</button>
+            <button className="btn btn-ghost" onClick={takeBack} disabled={thinking || history.length < 2}>
+              Take back
+            </button>
+          </div>
+
+          <div className="chess-meta">
+            <div className="pill">Engine depth<strong>{t.depth}</strong></div>
+            <div className="pill">Moves played<strong>{history.length}</strong></div>
+            <div className="pill">Turn<strong>{game.turn() === "w" ? "white" : "black"}</strong></div>
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+
+      <TweaksPanel title="Tweaks">
+        <TweakSection title="Aesthetic">
+          <TweakRadio
+            label="System"
+            value={t.aesthetic}
+            options={[{ value: "glass", label: "Glass" }, { value: "paper", label: "Paper" }]}
+            onChange={(v) => setTweak("aesthetic", v)}
+          />
+        </TweakSection>
+        <TweakSection title="Typography">
+          <TweakSelect
+            label="Display font"
+            value={t.font}
+            options={[
+              { value: "classic", label: "Fraunces - classic" },
+              { value: "editorial", label: "Instrument Serif - quieter" },
+              { value: "modern", label: "Bricolage - grotesque" },
+            ]}
+            onChange={(v) => setTweak("font", v)}
+          />
+        </TweakSection>
+        <TweakSection title="Engine">
+          <TweakSelect
+            label="Search depth"
+            value={String(t.depth)}
+            options={[
+              { value: "1", label: "1 — random-ish" },
+              { value: "2", label: "2 — quick" },
+              { value: "3", label: "3 — default" },
+              { value: "4", label: "4 — slower, sharper" },
+            ]}
+            onChange={(v) => setTweak("depth", Number(v))}
+          />
+        </TweakSection>
+        <TweakSection title="Atmosphere">
+          <TweakRadio
+            label="Floating orbs"
+            value={t.showOrbs ? "on" : "off"}
+            options={[{ value: "on", label: "On" }, { value: "off", label: "Off" }]}
+            onChange={(v) => setTweak("showOrbs", v === "on")}
+          />
+          <TweakRadio
+            label="Status bar"
+            value={t.showStatusBar ? "on" : "off"}
+            options={[{ value: "on", label: "On" }, { value: "off", label: "Off" }]}
+            onChange={(v) => setTweak("showStatusBar", v === "on")}
+          />
+        </TweakSection>
+      </TweaksPanel>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<ChessApp />);

--- a/site-shell.jsx
+++ b/site-shell.jsx
@@ -10,6 +10,7 @@ function SiteNav({ active = "home" }) {
     { id: "projects", label: "Projects", href: "projects.html" },
     { id: "writing",  label: "Writing",  href: "writing.html" },
     { id: "rewards",  label: "Referrals",  href: "rewards.html" },
+    { id: "chess",    label: "Chess",    href: "chess.html" },
   ];
 
   return (
@@ -69,6 +70,7 @@ function SiteFooter() {
                 <li><a href="projects.html">Projects</a></li>
                 <li><a href="writing.html">Writing</a></li>
                 <li><a href="rewards.html">Referrals</a></li>
+                <li><a href="chess.html">Chess</a></li>
               </ul>
             </div>
             <div className="foot-col">


### PR DESCRIPTION
## Summary
- **Data-pull agent** (`.github/workflows/cards-pull.yml`) — Mondays 14:00 UTC, scans Doctor of Credit / Frequent Miler / One Mile at a Time RSS for posts mentioning cards in `rewards-cards.jsx`, opens a digest issue. Logic in `.github/scripts/track_card_updates.py`.
- **Validation agent** (`.github/workflows/cards-validate.yml`) — daily image-link check (fails if a referenced image is missing) plus a PR-only LLM diff reviewer using `actions/ai-inference` against `openai/gpt-4o-mini` on the **free** GitHub Models tier; flags suspicious edits like fee flips, implausible welcome offers, removed signature perks, and mismatched referral hrefs.
- **Chess page** — `chess.html` / `chess.css` / `chess.jsx` running in-browser against a small minimax + alpha-beta engine using `chess.js` v0.10.3. Linked from nav and footer.

All three are free: workflows use the built-in `GITHUB_TOKEN`, GitHub Models has a free tier with `models: read`, and chess is pure client-side JS via CDN.

## Test plan
- [ ] Trigger `Pull card-news mentions` manually from the Actions tab and confirm an issue is created (or "No relevant items" logged).
- [ ] Open a trivial PR touching `rewards-cards.jsx` and confirm a `Card-diff review` comment appears.
- [ ] Temporarily rename one image and confirm `cards-validate` fails on the image-link job.
- [ ] Visit `/chess.html`, play a few moves, confirm engine responds and "New game" / "Take back" work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVyYG3gHXzZj28TKwyz34v)_