### PR TITLE
Add take-back button to home-page ChessBoard

### DIFF
--- a/globals.css
+++ b/globals.css
@@ -476,6 +476,12 @@ html[data-aesthetic="paper"] .chess-cell .piece.black { color: #15171a; text-sha
   line-height: 1.6;
 }
 html[data-aesthetic="paper"] .chess-side .moves { background: rgba(0,0,0,0.04); }
+.chess-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-self: flex-start;
+}
 .chess-reset {
   font-family: var(--font-mono);
   font-size: var(--fs-mono-xs);
@@ -488,9 +494,9 @@ html[data-aesthetic="paper"] .chess-side .moves { background: rgba(0,0,0,0.04); 
   color: var(--lumen);
   cursor: pointer;
   transition: all var(--dur-quick) var(--ease-out);
-  align-self: flex-start;
 }
-.chess-reset:hover { border-color: var(--amber); color: var(--amber); }
+.chess-reset:hover:not(:disabled) { border-color: var(--amber); color: var(--amber); }
+.chess-reset:disabled { opacity: 0.4; cursor: not-allowed; }
 
 @media (max-width: 720px) {
   .chess-wrap { grid-template-columns: 1fr; }

--- a/globals.jsx
+++ b/globals.jsx
@@ -635,6 +635,7 @@ function ChessBoard() {
   const [turn, setTurn] = gUseState("w");
   const [moves, setMoves] = gUseState([]);   // log of "e2-e4"
   const [thinking, setThinking] = gUseState(false);
+  const [history, setHistory] = gUseState([]); // snapshots taken before each white move
 
   gUseEffect(() => {
     if (turn !== "b" || thinking) return;
@@ -664,6 +665,7 @@ function ChessBoard() {
       if (isLegal) {
         const captured = board[r][c];
         const note = `${squareName(sel[0], sel[1])}${captured ? "x" : "-"}${squareName(r, c)}`;
+        setHistory(h => [...h, { board, moves }]);
         setBoard(applyMove(board, { from: sel, to: [r, c] }));
         setMoves(m => [...m, { ply: m.length + 1, t: "w", n: note }]);
         setSel(null);
@@ -683,6 +685,18 @@ function ChessBoard() {
   const reset = () => {
     setBoard(INITIAL.map(row => row.slice()));
     setSel(null); setLegal([]); setTurn("w"); setMoves([]); setThinking(false);
+    setHistory([]);
+  };
+
+  const takeBack = () => {
+    if (thinking || history.length === 0) return;
+    const prev = history[history.length - 1];
+    setBoard(prev.board);
+    setMoves(prev.moves);
+    setHistory(h => h.slice(0, -1));
+    setTurn("w");
+    setSel(null);
+    setLegal([]);
   };
 
   return (
@@ -741,7 +755,10 @@ function ChessBoard() {
                 <div key={m.ply}>{m.ply}. {m.t === "w" ? "" : "… "}{m.n}</div>
               ))}
         </div>
-        <button type="button" className="chess-reset" onClick={reset}>↻ Reset</button>
+        <div className="chess-actions">
+          <button type="button" className="chess-reset" onClick={reset}>↻ Reset</button>
+          <button type="button" className="chess-reset" onClick={takeBack} disabled={thinking || history.length === 0}>↶ Take back</button>
+        </div>
         <a className="link-amber" href="https://www.chess.com/" target="_blank" rel="noreferrer" style={{borderBottom:0, fontFamily:"var(--font-mono)", fontSize:11, letterSpacing:"0.12em", textTransform:"uppercase", color:"var(--violet)"}}>
           Real game on Chess.com →
         </a>


### PR DESCRIPTION
## Summary
Adds a Take back button to the home-page chess board next to Reset. Now that the engine plays automatically, a single misclick was a one-way trip — take-back pops the position back to the start of the user's previous turn (undoes both the engine's reply and the user's own move).

- New `history` state stack snapshots the board + move log right before each white move.
- Take back disabled while the engine is thinking or when no moves have been played.
- Reset clears the history alongside the rest of the state.

## Test plan
- [ ] Make a move, watch the engine reply, hit Take back, confirm both moves disappear from the log and the board returns to the prior position.
- [ ] Confirm the button is greyed out at the start of a fresh game and while "Engine thinking…" is showing.
- [ ] Confirm Reset still works mid-game.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVyYG3gHXzZj28TKwyz34v)_