### PR TITLE
Add take-back button to home-page ChessBoard

### DIFF
--- a/globals.css
+++ b/globals.css
@@ -476,6 +476,12 @@ html[data-aesthetic="paper"] .chess-cell .piece.black { color: #15171a; text-sha
   line-height: 1.6;
 }
 html[data-aesthetic="paper"] .chess-side .moves { background: rgba(0,0,0,0.04); }
+.chess-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-self: flex-start;
+}
 .chess-reset {
   font-family: var(--font-mono);
   font-size: var(--fs-mono-xs);
@@ -488,9 +494,9 @@ html[data-aesthetic="paper"] .chess-side .moves { background: rgba(0,0,0,0.04); 
   color: var(--lumen);
   cursor: pointer;
   transition: all var(--dur-quick) var(--ease-out);
-  align-self: flex-start;
 }
-.chess-reset:hover { border-color: var(--amber); color: var(--amber); }
+.chess-reset:hover:not(:disabled) { border-color: var(--amber); color: var(--amber); }
+.chess-reset:disabled { opacity: 0.4; cursor: not-allowed; }
 
 @media (max-width: 720px) {
   .chess-wrap { grid-template-columns: 1fr; }

--- a/globals.jsx
+++ b/globals.jsx
@@ -635,6 +635,7 @@ function ChessBoard() {
   const [turn, setTurn] = gUseState("w");
   const [moves, setMoves] = gUseState([]);   // log of "e2-e4"
   const [thinking, setThinking] = gUseState(false);
+  const [history, setHistory] = gUseState([]); // snapshots taken before each white move
 
   gUseEffect(() => {
     if (turn !== "b" || thinking) return;
@@ -664,6 +665,7 @@ function ChessBoard() {
       if (isLegal) {
         const captured = board[r][c];
         const note = `${squareName(sel[0], sel[1])}${captured ? "x" : "-"}${squareName(r, c)}`;
+        setHistory(h => [...h, { board, moves }]);
         setBoard(applyMove(board, { from: sel, to: [r, c] }));
         setMoves(m => [...m, { ply: m.length + 1, t: "w", n: note }]);
         setSel(null);
@@ -683,6 +685,18 @@ function ChessBoard() {
   const reset = () => {
     setBoard(INITIAL.map(row => row.slice()));
     setSel(null); setLegal([]); setTurn("w"); setMoves([]); setThinking(false);
+    setHistory([]);
+  };
+
+  const takeBack = () => {
+    if (thinking || history.length === 0) return;
+    const prev = history[history.length - 1];
+    setBoard(prev.board);
+    setMoves(prev.moves);
+    setHistory(h => h.slice(0, -1));
+    setTurn("w");
+    setSel(null);
+    setLegal([]);
   };
 
   return (
@@ -741,7 +755,10 @@ function ChessBoard() {
                 <div key={m.ply}>{m.ply}. {m.t === "w" ? "" : "… "}{m.n}</div>
               ))}
         </div>
-        <button type="button" className="chess-reset" onClick={reset}>↻ Reset</button>
+        <div className="chess-actions">
+          <button type="button" className="chess-reset" onClick={reset}>↻ Reset</button>
+          <button type="button" className="chess-reset" onClick={takeBack} disabled={thinking || history.length === 0}>↶ Take back</button>
+        </div>
         <a className="link-amber" href="https://www.chess.com/" target="_blank" rel="noreferrer" style={{borderBottom:0, fontFamily:"var(--font-mono)", fontSize:11, letterSpacing:"0.12em", textTransform:"uppercase", color:"var(--violet)"}}>
           Real game on Chess.com →
         </a>


### PR DESCRIPTION
The placeholder home-page board had a Reset button but no way to undo a single move. Now that the engine plays automatically, hanging a piece on accident was a one-way trip. Track a history stack of board state captured before each white move and add a Take back control next to Reset that pops the latest snapshot — restoring the position to the start of the user's previous turn.

Take back is disabled while the engine is thinking and when no moves have been played. Reset clears the history alongside the rest.