### PR TITLE
Add mobile navigation drawer and improve responsive design

### DIFF
--- a/bio.css
+++ b/bio.css
@@ -129,8 +129,15 @@ html[data-aesthetic="paper"] .social-tile.s-medium { color: #1a1a1a; }
 html[data-aesthetic="paper"] .social-tile.s-goodreads { color: #553B08; }
 
 @media (max-width: 760px) {
-  .bio-hero { grid-template-columns: 1fr; }
-  .bio-spec { grid-template-columns: 100px 1fr; }
+  .bio-hero { grid-template-columns: 1fr; gap: var(--s-5); }
+  .bio-spec { grid-template-columns: 100px 1fr; gap: 8px var(--s-3); }
+  .socials-card { padding: 14px 18px; }
+  .socials { gap: 22px; }
+}
+@media (max-width: 480px) {
+  .bio-spec { grid-template-columns: 1fr; gap: 4px; }
+  .bio-spec dt { padding-top: 10px; }
+  .bio-spec dt:first-of-type { padding-top: 0; }
 }
 
 /* Quote */

--- a/globals.css
+++ b/globals.css
@@ -79,7 +79,7 @@ html[data-aesthetic="paper"] .orb { mix-blend-mode: multiply; opacity: 0.18; fil
    cardinal ticks, and HUD give it the feel of a real piece of
    scientific gear rather than a floating circle.
    ───────────────────────────────────────────────────────────────────── */
-.wire-globe { position: relative; }
+.wire-globe { position: relative; max-width: 100%; }
 .wire-globe-mount {
   border-radius: 50%;
   overflow: hidden;
@@ -263,7 +263,10 @@ html[data-aesthetic="paper"] .wg-ring { border-color: rgba(94,71,166,0.55); }
 html[data-aesthetic="paper"] .wg-ring.wg-mer { border-color: rgba(176,108,40,0.45); }
 
 @media (max-width: 900px) {
-  .wireglobe-wrap { transform: scale(0.78); }
+  .wireglobe-wrap { transform: scale(0.78); transform-origin: center top; }
+}
+@media (max-width: 540px) {
+  .wireglobe-wrap { transform: scale(0.62); }
 }
 
 @keyframes orb-drift-1 {

--- a/home.css
+++ b/home.css
@@ -53,6 +53,13 @@
   font-variation-settings: "opsz" 144, "wght" 300;
   color: var(--lumen-2);
 }
+/* Hero name — uses a tight clamp because the full string ("Feruz
+   Urazaliev") needs to render on a single line down to a 320px viewport. */
+.hero h1.hero-name {
+  font-size: clamp(36px, 10vw, 120px);
+  letter-spacing: -0.04em;
+}
+.hero h1.hero-name span { font-weight: 700; }
 
 .hero-side {
   display: flex;
@@ -299,6 +306,10 @@
   .tile.tile-sm { grid-column: span 6; }
   .tile.tile-wide { grid-column: span 12; }
   .offgrid-grid { grid-template-columns: 1fr 1fr; }
+  /* Tablet hero — give the globe a bit more breathing room and let the
+     copy column stretch so the now-band doesn't crush its labels. */
+  .hero { padding-top: clamp(60px, 10vh, 120px); }
+  .hero-now { gap: var(--s-3); padding: 14px 18px; }
 }
 @media (max-width: 760px) {
   .hero { padding-top: clamp(48px, 10vh, 96px); }

--- a/home.css
+++ b/home.css
@@ -32,7 +32,7 @@
   .hero-grid--globe .hero-globe { justify-self: center; margin-top: var(--s-5); }
 }
 @media (max-width: 560px) {
-  .hero-grid--globe .hero-globe { transform: scale(0.7); margin-top: 0; }
+  .hero-grid--globe .hero-globe { margin-top: var(--s-3); }
 }
 /* .hero-stamp moved to site.css so inner pages get it too */
 
@@ -301,10 +301,32 @@
   .offgrid-grid { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 760px) {
-  .hero-grid { grid-template-columns: 1fr; }
+  .hero { padding-top: clamp(48px, 10vh, 96px); }
+  .hero-grid { grid-template-columns: 1fr; gap: var(--s-5); }
+  .hero h1 { font-size: clamp(48px, 13vw, 96px); }
+  .hero-stamp { gap: 12px; font-size: 10px; }
   .tiles { grid-template-columns: 1fr; }
-  .tile.tile-lg, .tile.tile-md, .tile.tile-sm, .tile.tile-wide { grid-column: span 12; }
-  .quote-block { grid-template-columns: 1fr; }
+  .tile { min-height: 220px; padding: 20px; }
+  .tile.tile-lg, .tile.tile-md, .tile.tile-sm, .tile.tile-wide {
+    grid-column: span 12;
+    min-height: 220px;
+  }
+  .tile-title { font-size: clamp(28px, 7vw, 40px); margin: var(--s-4) 0 var(--s-3); }
+  .quote-block {
+    grid-template-columns: 1fr;
+    padding: var(--s-5) var(--s-4);
+  }
   .quote-block .quote-mark { display: none; }
-  .hero-now { grid-template-columns: 1fr; }
+  .hero-now {
+    grid-template-columns: 1fr;
+    padding: 14px 16px;
+  }
+  .offgrid-grid { grid-template-columns: 1fr 1fr; gap: var(--s-2); }
+  .offgrid-tile { min-height: 144px; padding: 14px; }
+  .socials-card { padding: 14px 18px; }
+  .socials { gap: 18px; }
+}
+@media (max-width: 480px) {
+  .offgrid-grid { grid-template-columns: 1fr; }
+  .hero-grid--globe .hero-globe { transform: scale(0.6); margin-top: -20px; margin-bottom: -20px; }
 }

--- a/home.jsx
+++ b/home.jsx
@@ -136,9 +136,13 @@ function HomeApp() {
   const fmt  = time.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "America/Chicago" });
   const date = time.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "2-digit" });
 
+  // Trim the orb field on small screens — nine floating orbs read as
+  // "page is flying around" on a phone, and they cost GPU besides.
+  const orbCount = globeSize <= 280 ? 4 : globeSize <= 380 ? 6 : 9;
+
   return (
     <>
-      {tweaks.showOrbs && <OrbField count={9} />}
+      {tweaks.showOrbs && <OrbField count={orbCount} />}
       {tweaks.showStatusBar && <StatusBar />}
       <SiteNav active="home" />
 
@@ -153,8 +157,8 @@ function HomeApp() {
 
           <div className="hero-grid hero-grid--globe">
             <div className="hero-text">
-              <h1>
-                <span style={{fontWeight: 700, letterSpacing: "-0.04em", fontSize: "clamp(48px, 7vw, 120px)"}}>Feruz Urazaliev</span>
+              <h1 className="hero-name">
+                <span>Feruz Urazaliev</span>
               </h1>
               <p className="lead" style={{marginTop: "var(--s-4)", maxWidth: "52ch"}}>
                 Building data things. Metalcore on repeat. Occasionally losing at chess.

--- a/home.jsx
+++ b/home.jsx
@@ -94,6 +94,39 @@ function HomeApp() {
     else document.body.classList.remove("no-stars");
   }, [tweaks]);
 
+  // Globe size needs to match the viewport — at 420px on a 360px phone the
+  // canvas overflows the column and shoves the page sideways. Bucketing
+  // (rather than tracking every pixel) keeps the WebGL scene from
+  // re-instantiating on every resize tick.
+  const pickGlobeSize = () => {
+    if (typeof window === "undefined") return 420;
+    const w = window.innerWidth;
+    if (w < 420) return 240;
+    if (w < 560) return 280;
+    if (w < 768) return 320;
+    if (w < 980) return 380;
+    return 420;
+  };
+  const [globeSize, setGlobeSize] = hUseState(pickGlobeSize);
+  hUseEffect(() => {
+    let frame = null;
+    const onResize = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        setGlobeSize((prev) => {
+          const next = pickGlobeSize();
+          return next === prev ? prev : next;
+        });
+      });
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, []);
+
   // local clock for the now-band
   const [time, setTime] = hUseState(() => new Date());
   hUseEffect(() => {
@@ -131,7 +164,7 @@ function HomeApp() {
               </div>
             </div>
             <div className="hero-globe">
-              <WireGlobe size={420} />
+              <WireGlobe key={globeSize} size={globeSize} />
             </div>
           </div>
 

--- a/projects.css
+++ b/projects.css
@@ -99,6 +99,14 @@
   .proj-row { grid-template-columns: 50px 1fr 28px; }
   .proj-row .desc, .proj-row .meta { display: none; }
 }
+@media (max-width: 540px) {
+  .proj-row {
+    grid-template-columns: auto 1fr 28px;
+    gap: var(--s-3);
+    padding: 18px 4px;
+  }
+  .proj-row .title { font-size: 22px; }
+}
 
 /* Tech */
 .tech-cloud {
@@ -150,6 +158,7 @@
   color: var(--fg-muted);
 }
 @media (max-width: 1100px) { .certs { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 480px)  { .certs { grid-template-columns: 1fr; } }
 
 /* Education */
 .edu {
@@ -184,4 +193,12 @@
   color: var(--violet);
   letter-spacing: var(--tr-mono-up);
   text-transform: uppercase;
+}
+@media (max-width: 540px) {
+  .edu {
+    grid-template-columns: 1fr;
+    gap: var(--s-2);
+    padding: var(--s-4);
+  }
+  .edu h5 { font-size: 24px; }
 }

--- a/rewards.css
+++ b/rewards.css
@@ -161,6 +161,14 @@
   color: var(--fg-muted);
   text-align: right;
 }
+@media (max-width: 540px) {
+  .rw-section-head {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .rw-section-head .stamp-line { text-align: left; }
+  .rw-hero { padding: 24px 0 16px; }
+}
 
 .rw-list {
   display: grid;
@@ -356,6 +364,19 @@
   .rw-bonus { display: flex; gap: 12px; align-items: baseline; }
   .rw-cta { width: max-content; }
 }
+@media (max-width: 480px) {
+  .rw-card { grid-template-columns: 1fr; padding: 16px; gap: 12px; }
+  .rw-mark, .rw-mark.m-img, .rw-mark.m-img.m-square { grid-column: 1; }
+  .rw-body, .rw-bonus, .rw-cta { grid-column: 1; }
+  .rw-body .name { font-size: 20px; }
+  .rw-bonus .amt { font-size: 26px; }
+  .rw-cta {
+    width: 100%;
+    text-align: center;
+    justify-content: center;
+    display: inline-flex;
+  }
+}
 
 /* ─────────────────────────────────────────────────────────────────
    COUPON CARD — variant
@@ -417,6 +438,10 @@ html[data-aesthetic="paper"] .rw-coupon-code {
   .rw-coupon { grid-template-columns: 56px 1fr; padding-right: 16px; }
   .rw-coupon-code { grid-column: 2; }
   .rw-tear { display: none; }
+}
+@media (max-width: 480px) {
+  .rw-coupon { grid-template-columns: 1fr; padding: 16px; }
+  .rw-coupon-code { grid-column: 1; width: max-content; max-width: 100%; }
 }
 
 /* ─────────────────────────────────────────────────────────────────

--- a/site-shell.jsx
+++ b/site-shell.jsx
@@ -2,7 +2,9 @@
 const { useState, useEffect, useRef } = React;
 
 /* ─────────────────────────────────────────────────────────────────
-   SiteNav — sticky pill nav with brand, link list, and CTA
+   SiteNav — sticky pill nav with brand, link list, and CTA.
+   On narrow viewports the link list collapses into a hamburger
+   drawer that opens a full-screen sheet with the same links + CTA.
    ───────────────────────────────────────────────────────────────── */
 function SiteNav({ active = "home" }) {
   const links = [
@@ -12,14 +14,44 @@ function SiteNav({ active = "home" }) {
     { id: "rewards",  label: "Referrals",  href: "rewards.html" },
   ];
 
+  const [open, setOpen] = useState(false);
+
+  // Close on Escape; lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Snap closed when the viewport grows past the mobile breakpoint —
+  // otherwise an open drawer survives a desktop resize and traps the
+  // scrollable area off-screen.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(min-width: 861px)");
+    const onChange = (e) => { if (e.matches) setOpen(false); };
+    if (mq.addEventListener) mq.addEventListener("change", onChange);
+    else mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener("change", onChange);
+      else mq.removeListener(onChange);
+    };
+  }, []);
+
   return (
-    <nav className="nav">
+    <nav className={"nav" + (open ? " is-open" : "")}>
       <div className="nav-inner glass glass--pill">
         <a className="nav-brand" href="index.html">
           <span className="dot" />
           <span>Feruz Urazaliev</span>
         </a>
-        <div className="nav-links">
+        <div className="nav-links" id="primary-nav">
           {links.map(l => (
             <a
               key={l.id}
@@ -38,6 +70,60 @@ function SiteNav({ active = "home" }) {
         >
           Subscribe
         </a>
+        <button
+          type="button"
+          className={"nav-burger" + (open ? " is-active" : "")}
+          aria-label={open ? "Close menu" : "Open menu"}
+          aria-expanded={open}
+          aria-controls="mobile-menu"
+          onClick={() => setOpen(o => !o)}
+        >
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Mobile drawer — rendered always so the height transition can
+          run smoothly; gated by the .is-open modifier on the parent. */}
+      <div
+        id="mobile-menu"
+        className="nav-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+        hidden={!open}
+      >
+        <div
+          className="nav-drawer-backdrop"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
+        />
+        <div className="nav-drawer-panel glass">
+          <ul className="nav-drawer-links">
+            {links.map(l => (
+              <li key={l.id}>
+                <a
+                  href={l.href}
+                  className={"nav-drawer-link " + (active === l.id ? "is-active" : "")}
+                  onClick={() => setOpen(false)}
+                >
+                  <span className="lbl">{l.label}</span>
+                  <span className="arr" aria-hidden="true">↗</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <a
+            className="nav-drawer-cta"
+            href="https://medium.feruzurazaliev.com/subscribe"
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => setOpen(false)}
+          >
+            Subscribe ↗
+          </a>
+        </div>
       </div>
     </nav>
   );

--- a/site.css
+++ b/site.css
@@ -18,7 +18,32 @@ body {
   background-attachment: fixed;
   background-size: 140% 140%;
   background-position: 30% 20%;
+  /* Two declarations: browsers without `clip` support fall through to
+     `hidden`. `clip` is preferred because it doesn't create a scroll
+     container, which would otherwise interfere with position: sticky on
+     descendants in some browsers. */
   overflow-x: hidden;
+  overflow-x: clip;
+}
+
+/* ─── Mobile-friendly defaults — apply everywhere, not just below a
+       breakpoint. Prevents accidental horizontal scroll on phones. ─── */
+img, video, picture, svg:not([width]) {
+  max-width: 100%;
+  height: auto;
+}
+input, textarea, select, button {
+  max-width: 100%;
+}
+/* Let flex / grid children shrink below their content min-size so long
+   strings (URLs, emails) don't burst the page on mobile. */
+.foot-col, .foot-col li, .foot-col a,
+.hero-stamp, .now-band, .hero-now,
+.proj-row, .wr-row, .rw-card, .rw-coupon,
+.bio-spec, .spec, .nav-inner, .nav-brand,
+.tile, .tile-body, .read-now, .listen-row,
+.gb-entry, .gb-form, .wine-card {
+  min-width: 0;
 }
 
 /* tiny stars layer — subtle, low-contrast */

--- a/site.css
+++ b/site.css
@@ -7,7 +7,7 @@
 
 :root {
   --nav-h: 64px;
-  --container-pad: clamp(20px, 4vw, 48px);
+  --container-pad: clamp(16px, 4vw, 48px);
 }
 
 html, body { margin: 0; }
@@ -66,6 +66,10 @@ body::before {
   align-items: center;
   padding: 10px 14px 10px 18px;
   border-radius: var(--r-pill);
+  position: relative;
+  /* Stays above the mobile drawer backdrop so the burger can dismiss
+     the menu without the backdrop intercepting the click. */
+  z-index: 2;
 }
 .nav-brand {
   display: inline-flex;
@@ -150,6 +154,174 @@ body::before {
   transform: translateY(-1px);
 }
 
+/* ─── Hamburger toggle (mobile only) ─── */
+.nav-burger {
+  display: none;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  width: 44px;
+  height: 44px;
+  margin-right: -6px;
+  border-radius: 999px;
+  cursor: pointer;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  color: var(--lumen);
+  transition: background var(--dur-quick) var(--ease-out);
+}
+.nav-burger:hover { background: rgba(255,255,255,0.06); }
+.nav-burger:focus-visible {
+  outline: 2px solid var(--violet);
+  outline-offset: 2px;
+}
+.nav-burger span {
+  display: block;
+  width: 20px;
+  height: 1.5px;
+  border-radius: 2px;
+  background: currentColor;
+  transition: transform var(--dur-base) var(--ease-out),
+              opacity var(--dur-quick) var(--ease-out);
+  transform-origin: center;
+}
+.nav-burger.is-active span:nth-child(1) {
+  transform: translateY(6.5px) rotate(45deg);
+}
+.nav-burger.is-active span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+.nav-burger.is-active span:nth-child(3) {
+  transform: translateY(-6.5px) rotate(-45deg);
+}
+
+/* ─── Mobile drawer ─── */
+.nav-drawer {
+  position: fixed;
+  inset: 0;
+  /* Sits inside the nav stacking context but below .nav-inner so the
+     pill (with the burger / close button) remains tappable. */
+  z-index: 1;
+  display: none;
+}
+.nav.is-open .nav-drawer { display: block; }
+.nav-drawer[hidden] { display: none; }
+.nav-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 7, 11, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: drawer-fade var(--dur-base) var(--ease-out);
+}
+html[data-aesthetic="paper"] .nav-drawer-backdrop {
+  background: rgba(21, 23, 26, 0.35);
+}
+.nav-drawer-panel {
+  position: absolute;
+  /* Sits just below the mobile pill (12px top + ~56px pill + 8px gap). */
+  top: 76px;
+  left: 12px;
+  right: 12px;
+  max-width: 460px;
+  margin-inline: auto;
+  padding: 14px;
+  border-radius: var(--r-4);
+  display: grid;
+  gap: 6px;
+  animation: drawer-in var(--dur-base) var(--ease-out);
+  max-height: calc(100vh - 92px);
+  max-height: calc(100dvh - 92px);
+  overflow-y: auto;
+}
+.nav-drawer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 2px;
+}
+.nav-drawer-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--r-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-sm);
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--lumen-2);
+  border-bottom: 0;
+  transition: background var(--dur-quick) var(--ease-out),
+              color var(--dur-quick) var(--ease-out);
+  min-height: 48px;
+}
+.nav-drawer-link:hover {
+  background: rgba(255,255,255,0.05);
+  color: var(--lumen);
+  border-bottom: 0;
+}
+html[data-aesthetic="paper"] .nav-drawer-link:hover {
+  background: rgba(21,23,26,0.05);
+}
+.nav-drawer-link.is-active {
+  background: rgba(139, 92, 255, 0.12);
+  color: var(--lumen);
+}
+.nav-drawer-link.is-active::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--violet);
+  box-shadow: 0 0 10px var(--violet-glow);
+  margin-right: -2px;
+}
+.nav-drawer-link .lbl { flex: 1; }
+.nav-drawer-link .arr { color: var(--fg-faint); font-family: var(--font-display); }
+.nav-drawer-cta {
+  margin-top: 6px;
+  padding: 14px 18px;
+  border-radius: var(--r-pill);
+  background: var(--violet);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-sm);
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  text-align: center;
+  border-bottom: 0;
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.nav-drawer-cta:hover {
+  background: var(--violet-bright);
+  color: #fff;
+  border-bottom: 0;
+}
+@keyframes drawer-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes drawer-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-drawer-backdrop,
+  .nav-drawer-panel { animation: none; }
+  .nav-burger span { transition: none; }
+}
+
 /* ─── Footer ─── */
 .site-foot {
   margin-top: var(--s-9);
@@ -199,6 +371,8 @@ html[data-aesthetic="paper"] .foot-spline { opacity: 0.35; }
   font-size: var(--fs-mono-sm);
   color: var(--lumen-2);
   border-bottom: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .foot-col a:hover { color: var(--violet-bright); border-bottom: 0; }
 
@@ -437,6 +611,7 @@ html[data-aesthetic="paper"] .foot-spline { opacity: 0.35; }
 }
 
 /* ─── Eyebrow ─── */
+.eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -460,19 +635,72 @@ a.unstyle, .nav-brand, .nav-link, .nav-cta, .btn,
 
 /* ─── Responsive ─── */
 @media (max-width: 860px) {
+  .nav {
+    top: 12px;
+    margin-top: 12px;
+    width: calc(100% - 24px);
+  }
   .nav-inner {
-    grid-template-columns: auto 1fr auto;
-    gap: 10px;
-    padding: 8px 8px 8px 14px;
+    grid-template-columns: 1fr auto auto;
+    gap: 8px;
+    padding: 6px 6px 6px 14px;
   }
   .nav-links { display: none; }
+  .nav-cta {
+    padding: 8px 14px;
+    font-size: var(--fs-mono-xs);
+  }
+  .nav-burger { display: inline-flex; }
+  .nav-brand span:not(.dot) {
+    /* Keep the brand on a single line; truncate if absolutely needed. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .section-head {
     grid-template-columns: 1fr;
     align-items: start;
+    gap: var(--s-3);
   }
+  .section-head h2 {
+    font-size: clamp(36px, 9vw, 64px);
+  }
+
   .foot-grid {
     grid-template-columns: 1fr 1fr;
   }
+  .foot-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    text-align: left;
+  }
+}
+
+@media (max-width: 540px) {
+  .nav { width: calc(100% - 16px); }
+  .nav-inner { padding: 6px 6px 6px 12px; }
+  .nav-brand { font-size: 11px; gap: 8px; }
+  .nav-cta {
+    /* Tuck the CTA into the drawer at very narrow widths so the header
+       has breathing room for the brand + burger. */
+    display: none;
+  }
+  .foot-grid {
+    grid-template-columns: 1fr;
+    gap: var(--s-4);
+  }
+  .now-band {
+    padding: 12px 16px;
+    gap: var(--s-2);
+  }
+  .now-band .now-time {
+    margin-left: 0;
+  }
+  .page-head {
+    padding: clamp(60px, 10vh, 100px) 0 var(--s-5);
+  }
+  .marquee-item { font-size: clamp(60px, 18vw, 110px); }
 }
 
 /* ─── Reveal anim ─── */

--- a/writing.css
+++ b/writing.css
@@ -63,6 +63,16 @@
   .wr-row { grid-template-columns: 70px 1fr 28px; }
   .wr-row .summary, .wr-row .meta { display: none; }
 }
+@media (max-width: 540px) {
+  .wr-row {
+    grid-template-columns: 1fr 28px;
+    gap: 6px var(--s-3);
+    padding: 18px 4px;
+  }
+  .wr-row .date { grid-column: 1 / -1; }
+  .wr-row .title { font-size: 22px; }
+  .wr-row .arr { grid-row: 2; }
+}
 
 /* Subscribe / now band */
 .wr-callouts {
@@ -153,4 +163,12 @@
 
 @media (max-width: 900px) {
   .wr-callouts { grid-template-columns: 1fr; }
+}
+@media (max-width: 540px) {
+  .wr-sub { padding: var(--s-5) var(--s-4); }
+  .wr-sub h3 { font-size: clamp(28px, 8vw, 40px); }
+  .wr-sub form { flex-direction: column; }
+  .wr-sub input { width: 100%; min-width: 0; }
+  .wr-sub .btn { width: 100%; justify-content: center; }
+  .wr-side { padding: var(--s-4); }
 }


### PR DESCRIPTION
## Summary
This PR adds a mobile-friendly hamburger menu with a full-screen navigation drawer, improves responsive layouts across all pages, and fixes overflow issues on narrow viewports.

## Key Changes

**Navigation & Mobile Menu**
- Implemented hamburger toggle button (`.nav-burger`) that appears on viewports ≤860px
- Added full-screen mobile drawer (`.nav-drawer`) with backdrop, animations, and keyboard support (Escape to close)
- Drawer automatically closes when viewport expands past mobile breakpoint or when links are clicked
- Body scroll is locked while drawer is open
- Navigation pill now has `z-index: 2` to stay above drawer backdrop

**Responsive Improvements**
- Added comprehensive mobile-first CSS with breakpoints at 860px, 760px, 560px, 540px, and 480px
- Reduced default container padding from 20px to 16px minimum
- Added `min-width: 0` to flex/grid children to prevent long strings (URLs, emails) from breaking layouts
- Improved text wrapping with `word-break: break-word` and `overflow-wrap: anywhere` on footer links
- Added `max-width: 100%` to media elements and form inputs

**Globe & Hero Section**
- Implemented responsive globe sizing with bucketed breakpoints (240px–420px) to prevent canvas overflow
- Removed fixed scale transform on small screens in favor of dynamic sizing
- Added `.hero-name` class with responsive font sizing using `clamp(36px, 10vw, 120px)`
- Adjusted hero padding and spacing for tablet/mobile layouts

**Content Cards & Grids**
- Updated tile, card, and grid layouts for mobile (single column where appropriate)
- Adjusted padding and gaps across reward cards, project rows, writing rows, and education sections
- Reduced orb count on small screens (4 orbs ≤280px, 6 orbs ≤380px, 9 orbs otherwise) for performance

**Accessibility & UX**
- Added proper ARIA labels and roles to hamburger button and drawer dialog
- Implemented smooth animations with reduced-motion support
- Ensured 48px minimum touch targets for interactive elements
- Brand text truncates with ellipsis on narrow screens instead of wrapping

## Implementation Details
- Mobile drawer uses `position: fixed` with `inset: 0` and sits at `z-index: 1` (below the nav pill at `z-index: 2`)
- Drawer animations use keyframes (`drawer-fade`, `drawer-in`) with configurable durations
- Viewport resize listener uses `requestAnimationFrame` to debounce globe size recalculations
- Drawer state is managed in React with cleanup for event listeners and body overflow restoration

https://claude.ai/code/session_016Qeu5nXmvYoVtvtgpbyYnW