### PR TITLE
Add Chess.com live dossier card with player stats and recent games

### DIFF
--- a/globals.css
+++ b/globals.css
@@ -507,6 +507,124 @@ html[data-aesthetic="paper"] .chess-side .moves { background: rgba(0,0,0,0.04); 
 }
 
 /* ─────────────────────────────────────────────────────────────────────
+   CHESS DOSSIER — live snapshot card above the playable board
+   ───────────────────────────────────────────────────────────────────── */
+.chess-dossier {
+  padding: var(--s-5);
+  border-radius: var(--r-3);
+  display: grid;
+  gap: var(--s-4);
+  margin-bottom: var(--s-4);
+}
+.cd-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-xs);
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--lumen-3);
+  flex-wrap: wrap;
+}
+.cd-live { display: inline-flex; align-items: center; gap: 8px; }
+.cd-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+  transition: background var(--dur-quick) var(--ease-out);
+}
+.cd-dot.is-on  { background: #4ade80; box-shadow: 0 0 8px rgba(74,222,128,0.6); }
+.cd-dot.is-off { background: var(--fg-faint); }
+.cd-id { display: inline-flex; align-items: center; gap: 8px; }
+.cd-id a {
+  color: var(--lumen);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--hairline-strong);
+  text-transform: none;
+  font-family: var(--font-mono);
+}
+.cd-id a:hover { color: var(--amber); border-bottom-color: var(--amber); }
+.cd-flag { font-size: 14px; }
+.cd-since { color: var(--fg-faint); }
+
+.cd-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--s-3);
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--hairline);
+}
+.cd-stat { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+.cd-stat-lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.cd-stat-val {
+  font-family: var(--font-display);
+  font-variation-settings: "opsz" 144;
+  font-weight: 380;
+  font-size: 28px;
+  line-height: 1;
+  color: var(--lumen);
+  letter-spacing: -0.02em;
+}
+
+.cd-last {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--hairline);
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-xs);
+  letter-spacing: var(--tr-mono-up);
+  text-transform: uppercase;
+  color: var(--lumen-3);
+  flex-wrap: wrap;
+}
+.cd-last-lbl { color: var(--fg-faint); }
+.cd-last-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--lumen);
+  text-decoration: none;
+}
+.cd-last-row:hover { color: var(--amber); }
+.cd-last-row:hover .cd-arrow { transform: translateX(2px); }
+.cd-arrow { transition: transform var(--dur-quick) var(--ease-out); }
+.cd-result {
+  display: inline-grid; place-items: center;
+  min-width: 22px; height: 22px; padding: 0 6px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+}
+.cd-r-W { background: rgba(74,222,128,0.15);  color: #4ade80; border: 1px solid rgba(74,222,128,0.4); }
+.cd-r-L { background: rgba(255,107,107,0.12); color: #ff8b8b; border: 1px solid rgba(255,107,107,0.35); }
+.cd-r-D { background: rgba(255,255,255,0.05); color: var(--lumen-3); border: 1px solid var(--hairline-strong); }
+.cd-vs   { color: var(--fg-faint); }
+.cd-opp  { color: var(--lumen); text-transform: none; font-family: var(--font-mono); }
+.cd-meta { color: var(--fg-faint); }
+.cd-last-empty { color: var(--fg-faint); }
+
+html[data-aesthetic="paper"] .cd-r-W { color: #2e8b57; background: rgba(46,139,87,0.10); border-color: rgba(46,139,87,0.45); }
+html[data-aesthetic="paper"] .cd-r-L { color: #b1422f; background: rgba(177,66,47,0.08);  border-color: rgba(177,66,47,0.40); }
+html[data-aesthetic="paper"] .cd-r-D { background: rgba(0,0,0,0.04); }
+
+@media (max-width: 540px) {
+  .cd-stats { grid-template-columns: repeat(2, 1fr); }
+  .cd-stat-val { font-size: 24px; }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
    LISTENING — list with tabs (recent / top artists / albums / tracks)
    ───────────────────────────────────────────────────────────────────── */
 .listen-carousel {

--- a/globals.jsx
+++ b/globals.jsx
@@ -768,6 +768,126 @@ function ChessBoard() {
 }
 
 /* ─────────────────────────────────────────────────────────────────
+   ChessDossier — live snapshot from the public Chess.com REST API.
+   Pulls /player, /player/stats, /player/is-online, and the latest
+   monthly archive to surface the most recent game. No auth needed.
+   ───────────────────────────────────────────────────────────────── */
+const CHESS_USER = "urazalievf";
+
+function codeToFlag(cc) {
+  if (!cc || cc.length !== 2) return "";
+  return cc.toUpperCase().replace(/./g, c => String.fromCodePoint(127397 + c.charCodeAt(0)));
+}
+
+function ChessDossier() {
+  const [data, setData] = gUseState({
+    online: null,
+    country: "",
+    joined: null,
+    rapid: null, blitz: null, bullet: null, puzzles: null,
+    lastGame: null,
+  });
+
+  gUseEffect(() => {
+    const base = `https://api.chess.com/pub/player/${CHESS_USER}`;
+
+    fetch(base).then(r => r.json()).then(p => {
+      const cc = p?.country ? p.country.split("/").pop() : "";
+      setData(d => ({ ...d, country: cc, joined: p?.joined || null }));
+    }).catch(() => {});
+
+    fetch(`${base}/stats`).then(r => r.json()).then(s => {
+      setData(d => ({
+        ...d,
+        rapid:   s?.chess_rapid?.last?.rating  ?? null,
+        blitz:   s?.chess_blitz?.last?.rating  ?? null,
+        bullet:  s?.chess_bullet?.last?.rating ?? null,
+        puzzles: s?.tactics?.highest?.rating   ?? null,
+      }));
+    }).catch(() => {});
+
+    fetch(`${base}/is-online`).then(r => r.json()).then(o => {
+      setData(d => ({ ...d, online: !!o?.online }));
+    }).catch(() => {});
+
+    fetch(`${base}/games/archives`).then(r => r.json()).then(a => {
+      const urls = a?.archives || [];
+      if (!urls.length) return null;
+      return fetch(urls[urls.length - 1]).then(r => r.json()).then(arch => {
+        const games = arch?.games || [];
+        if (!games.length) return;
+        const g = games[games.length - 1];
+        const meIsWhite = g?.white?.username?.toLowerCase() === CHESS_USER;
+        const mine = meIsWhite ? g.white : g.black;
+        const opp  = meIsWhite ? g.black : g.white;
+        const draws = new Set(["agreed","stalemate","repetition","insufficient","50move","timevsinsufficient"]);
+        const result = mine?.result === "win" ? "W" : draws.has(mine?.result) ? "D" : "L";
+        setData(d => ({
+          ...d,
+          lastGame: {
+            result,
+            opponent:  opp?.username || "—",
+            gameUrl:   g.url || null,
+            timeClass: g.time_class || "—",
+            endTime:   g.end_time || null,
+          },
+        }));
+      });
+    }).catch(() => {});
+  }, []);
+
+  const stats = [
+    { key: "rapid",   lbl: "Rapid",   v: data.rapid   },
+    { key: "blitz",   lbl: "Blitz",   v: data.blitz   },
+    { key: "bullet",  lbl: "Bullet",  v: data.bullet  },
+    { key: "puzzles", lbl: "Puzzles", v: data.puzzles },
+  ];
+  const joinedYear = data.joined ? new Date(data.joined * 1000).getFullYear() : null;
+
+  return (
+    <div className="chess-dossier glass">
+      <div className="cd-head">
+        <span className="cd-live">
+          <span className={"cd-dot " + (data.online ? "is-on" : "is-off")} />
+          {data.online === null ? "Chess.com" : data.online ? "Online now" : "Offline"}
+        </span>
+        <span className="cd-id">
+          {data.country && <span className="cd-flag" aria-hidden="true">{codeToFlag(data.country)}</span>}
+          <a href={`https://www.chess.com/member/${CHESS_USER}`} target="_blank" rel="noreferrer">
+            {CHESS_USER}
+          </a>
+          {joinedYear && <span className="cd-since">· since {joinedYear}</span>}
+        </span>
+      </div>
+
+      <div className="cd-stats">
+        {stats.map(s => (
+          <div key={s.key} className="cd-stat">
+            <div className="cd-stat-lbl">{s.lbl}</div>
+            <div className="cd-stat-val">{s.v != null ? s.v : "—"}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="cd-last">
+        <span className="cd-last-lbl">Last game</span>
+        {data.lastGame ? (
+          <a className="cd-last-row" href={data.lastGame.gameUrl} target="_blank" rel="noreferrer">
+            <span className={"cd-result cd-r-" + data.lastGame.result}>{data.lastGame.result}</span>
+            <span className="cd-vs">vs</span>
+            <span className="cd-opp">{data.lastGame.opponent}</span>
+            <span className="cd-meta">{data.lastGame.timeClass} · {relativeTime(data.lastGame.endTime)}</span>
+            <span className="cd-arrow" aria-hidden="true">↗</span>
+          </a>
+        ) : (
+          <span className="cd-last-empty">—</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────
    Guestbook — local-storage-backed
    ───────────────────────────────────────────────────────────────── */
 const GB_KEY = "fu-guestbook-v1";

--- a/home.jsx
+++ b/home.jsx
@@ -1,4 +1,4 @@
-/* global React, ReactDOM, SiteNav, SiteFooter, useTweaks, TweaksPanel, TweakSection, TweakRadio, TweakSelect, OrbField, StatusBar, CountUp, ListeningCarousel, Guestbook, ReadingNow, ChessBoard, WineCard, WireGlobe, GoodreadsQuote, LiveCounters, GitHubContributions */
+/* global React, ReactDOM, SiteNav, SiteFooter, useTweaks, TweaksPanel, TweakSection, TweakRadio, TweakSelect, OrbField, StatusBar, CountUp, ListeningCarousel, Guestbook, ReadingNow, ChessBoard, ChessDossier, WineCard, WireGlobe, GoodreadsQuote, LiveCounters, GitHubContributions */
 const { useEffect: hUseEffect, useState: hUseState } = React;
 
 const HOME_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -306,8 +306,9 @@ function HomeApp() {
         <section data-screen-label="Chess">
           <div className="hero-stamp">
             <span><span className="num">008</span> / Chess board</span>
-            <span style={{marginLeft: 'auto', color: 'var(--fg-faint)'}}>have a go</span>
+            <span style={{marginLeft: 'auto', color: 'var(--fg-faint)'}}>live dossier · have a go</span>
           </div>
+          <ChessDossier />
           <ChessBoard />
         </section>
 


### PR DESCRIPTION
## Summary
Adds a new `ChessDossier` component that displays live Chess.com player statistics and recent game information above the playable chess board. The component fetches data from the public Chess.com REST API without requiring authentication.

## Key Changes
- **New `ChessDossier` component** in `globals.jsx` that:
  - Fetches player profile, stats, online status, and game archives from Chess.com API
  - Displays current online status with a live indicator dot
  - Shows player country flag, username, and join year
  - Renders rating statistics for Rapid, Blitz, Bullet, and Puzzle modes
  - Shows the most recent game with result (W/D/L), opponent, time class, and relative timestamp
  - Includes a link to the full game on Chess.com
  
- **Comprehensive styling** in `globals.css` for the dossier card:
  - Glass-morphism design matching the site aesthetic
  - Responsive grid layout (4 columns on desktop, 2 on mobile)
  - Color-coded result badges (green for wins, red for losses, neutral for draws)
  - Smooth transitions and hover effects
  - Support for both default and "paper" aesthetic themes
  
- **Updated `home.jsx`** to:
  - Import the new `ChessDossier` component
  - Integrate the dossier card into the Chess section above the board

## Implementation Details
- Uses Chess.com's public API endpoints: `/player`, `/player/stats`, `/player/is-online`, and `/games/archives`
- Implements `codeToFlag()` utility to convert country codes to Unicode flag emojis
- Gracefully handles missing data with fallback values ("—")
- Fetches are non-blocking with `.catch()` handlers to prevent errors from breaking the UI
- Responsive design with breakpoint at 540px for mobile optimization

https://claude.ai/code/session_01XpKDoD38WPavNbpzgdwA6K